### PR TITLE
changed Context to be interface 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ func main() {
 	server := stk.NewServer(&config)
 
 	// add routes
-	server.Get("/", func(c *stk.Context) {
+	server.Get("/", func(c stk.Context) {
 		c.Status(http.StatusOK).JSONResponse(stk.Map{"message": "Hello World"})
 	})
 
@@ -50,7 +50,7 @@ you can add any middleware by simply creating a function like this and adding it
 
 ```go
 middleware := func(next stk.HandlerFunc) stk.HandlerFunc {
-	return func(c *stk.Context) {
+	return func(c stk.Context) {
 		if ctx.Request.URL.Path == "/blocked" {
   			ctx.Status(http.StatusForbidden).JSONResponse("blocked")
 			return

--- a/context.go
+++ b/context.go
@@ -9,13 +9,13 @@ import (
 	"go.uber.org/zap"
 )
 
-type Context struct {
-	Request *http.Request
-	Writer  http.ResponseWriter
+type context struct {
+	request *http.Request
+	writer  http.ResponseWriter
 
-	Params httprouter.Params
+	params httprouter.Params
 
-	Logger *zap.Logger
+	logger *zap.Logger
 
 	allowedOrigins []string
 	responseStatus int
@@ -24,55 +24,74 @@ type Context struct {
 
 type Map map[string]interface{}
 
-// Status sets the status code of the response
-func (c *Context) Status(status int) *Context {
-	c.responseStatus = status
-	return c
+type Context interface {
+	// http objects
+	GetRequest() *http.Request
+	GetWriter() http.ResponseWriter
+
+	// get data from request
+	GetParam(key string) string
+	GetQueryParam(key string) string
+	GetAllowedOrigins() []string
+	DecodeJSONBody(v interface{}) error
+
+	// set data for response
+	Status(status int) Context
+	SetHeader(string, string)
+	RawResponse(raw []byte)
+	JSONResponse(data interface{})
+
+	// logger
+	Logger() *zap.Logger
 }
 
-// JSONResponse marshals the provided interface into JSON and writes it to the response writer
-// If there is an error in marshalling the JSON, an internal server error is returned
-func (c *Context) JSONResponse(data interface{}) {
-	response, err := json.Marshal(data)
-	// Set the content type to JSON
-	c.Writer.Header().Set("Content-Type", "application/json")
-
-	// Check if there is an error in marshalling the JSON (internal server error)
-	if err != nil {
-		c.responseStatus = http.StatusInternalServerError
-		c.responseBody = []byte(ErrInternalServer.Error())
-		return
+func NewContext(r *http.Request, w http.ResponseWriter) Context {
+	return &context{
+		request: r,
+		writer:  w,
 	}
-
-	c.responseBody = response
 }
 
-func (c *Context) GetParam(key string) string {
-	return c.Params.ByName(key)
+func (c *context) GetRequest() *http.Request {
+	return c.request
 }
 
-func (c *Context) GetQueryParam(key string) string {
-	return c.Request.URL.Query().Get(key)
+func (c *context) GetWriter() http.ResponseWriter {
+	return c.writer
 }
 
-func (c *Context) DecodeJSONBody(v interface{}) error {
+// GetParam gets the params within the path mentioned as a wildcard
+func (c *context) GetParam(key string) string {
+	return c.params.ByName(key)
+}
+
+// GetQueryParam gets the query parameters passed eg: /?name=value
+func (c *context) GetQueryParam(key string) string {
+	return c.request.URL.Query().Get(key)
+}
+
+func (c *context) GetAllowedOrigins() []string {
+	return c.allowedOrigins
+}
+
+func (c *context) DecodeJSONBody(v interface{}) error {
 	bodySizeLimit := int64(1 << 20) // 1 MB
 
 	// Set a maximum limit for the request body size to avoid possible malicious requests
-	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, bodySizeLimit)
+	c.request.Body = http.MaxBytesReader(c.writer, c.request.Body, bodySizeLimit)
 
 	// Manually check if the request body size exceeds the limit
-	if c.Request.ContentLength > bodySizeLimit {
-		c.Writer.Header().Set("Content-Type", "application/json")
-		http.Error(c.Writer, ErrBodyTooLarge.Error(), http.StatusRequestEntityTooLarge)
+	if c.request.ContentLength > bodySizeLimit {
+		c.writer.Header().Set("Content-Type", "application/json")
+		http.Error(c.writer, ErrBodyTooLarge.Error(), http.StatusRequestEntityTooLarge)
 		return ErrBodyTooLarge
 	}
 
 	// Decode the JSON body into the provided interface
-	decoder := json.NewDecoder(c.Request.Body)
+	decoder := json.NewDecoder(c.request.Body)
 	err := decoder.Decode(v)
 
-	defer c.Request.Body.Close()
+	defer c.request.Body.Close()
 
 	// Check if there is an error in decoding the JSON, and return a user-friendly error message
 	if err != nil {
@@ -88,10 +107,39 @@ func (c *Context) DecodeJSONBody(v interface{}) error {
 	return nil
 }
 
-func (c *Context) GetAllowedOrigins() []string {
-	return c.allowedOrigins
+// Status sets the status code of the response
+func (c *context) Status(status int) Context {
+	c.responseStatus = status
+	return c
 }
 
-func (c *Context) RawResponse(raw []byte) {
+// sets response header key value
+func (c *context) SetHeader(key string, value string) {
+	c.writer.Header().Add(key, value)
+}
+
+// JSONResponse marshals the provided interface into JSON and writes it to the response writer
+// If there is an error in marshalling the JSON, an internal server error is returned
+func (c *context) JSONResponse(data interface{}) {
+	response, err := json.Marshal(data)
+	// Set the content type to JSON
+	c.writer.Header().Set("Content-Type", "application/json")
+
+	// Check if there is an error in marshalling the JSON (internal server error)
+	if err != nil {
+		c.responseStatus = http.StatusInternalServerError
+		c.responseBody = []byte(ErrInternalServer.Error())
+		return
+	}
+
+	c.responseBody = response
+}
+
+// sets response body as byte array
+func (c *context) RawResponse(raw []byte) {
 	c.responseBody = raw
+}
+
+func (c *context) Logger() *zap.Logger {
+	return c.logger
 }

--- a/context.go
+++ b/context.go
@@ -45,13 +45,6 @@ type Context interface {
 	Logger() *zap.Logger
 }
 
-func NewContext(r *http.Request, w http.ResponseWriter) Context {
-	return &context{
-		request: r,
-		writer:  w,
-	}
-}
-
 func (c *context) GetRequest() *http.Request {
 	return c.request
 }

--- a/context_test.go
+++ b/context_test.go
@@ -223,18 +223,23 @@ func TestDecodeJSONBody(t *testing.T) {
 			req := httptest.NewRequest("POST", "/", body)
 			resp := httptest.NewRecorder()
 
-			context := stk.NewContext(req, resp)
+			server := stk.NewServer(&stk.ServerConfig{})
 
-			var res SampleStruct
-			err := context.DecodeJSONBody(&res)
+			server.Post("/", func(c stk.Context) {
+				var res SampleStruct
+				err := c.DecodeJSONBody(&res)
 
-			if !errors.Is(err, tt.expectedErr) {
-				t.Errorf("Expected error to be '%v', got '%v'", tt.expectedErr, err)
-			}
+				if !errors.Is(err, tt.expectedErr) {
+					t.Errorf("Expected error to be '%v', got '%v'", tt.expectedErr, err)
+				}
 
-			if err == nil && res != tt.expectedResult {
-				t.Errorf("Expected result to be '%v', got '%v'", tt.expectedResult, res)
-			}
+				if err == nil && res != tt.expectedResult {
+					t.Errorf("Expected result to be '%v', got '%v'", tt.expectedResult, res)
+				}
+			})
+
+			server.Router.ServeHTTP(resp, req)
+
 		})
 	}
 }

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -17,10 +17,10 @@ const (
 )
 
 func CORS(next stk.HandlerFunc) stk.HandlerFunc {
-	return func(c *stk.Context) {
+	return func(c stk.Context) {
 		allowedOrigins := getAllowedOrigins(c.GetAllowedOrigins())
 
-		origin := c.Request.Header.Get("Host")
+		origin := c.GetRequest().Header.Get("Host")
 		// Check if the origin is in the allowedOrigins list
 		isAllowed := false
 		for _, allowedOrigin := range allowedOrigins {
@@ -32,13 +32,13 @@ func CORS(next stk.HandlerFunc) stk.HandlerFunc {
 
 		if !isAllowed {
 			c.Status(http.StatusForbidden)
-			c.Writer.Header().Set("Content-Type", "text/plain")
+			c.SetHeader("Content-Type", "text/plain")
 			c.RawResponse([]byte("Forbidden"))
 			return
 		}
 
 		// Set CORS headers
-		headers := c.Writer.Header()
+		headers := c.GetWriter().Header()
 		// TODO: Make this configurable
 		headers.Set(AccessControlAllowOrigin, origin)
 		headers.Set(AccessControlAllowMethods, defaultAllowMethods)

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -21,7 +21,7 @@ func TestCORSDefault(t *testing.T) {
 	s.Use(middleware.CORS)
 
 	// Register a test route and handler
-	s.Get("/", func(c *stk.Context) {
+	s.Get("/", func(c stk.Context) {
 		c.Status(http.StatusOK).JSONResponse("OK")
 	})
 
@@ -67,7 +67,7 @@ func TestCORSAllowedOrigin(t *testing.T) {
 	s.Use(middleware.CORS)
 
 	// Register a test route and handler
-	s.Get("/", func(c *stk.Context) {
+	s.Get("/", func(c stk.Context) {
 		c.Status(http.StatusOK).JSONResponse("OK")
 	})
 

--- a/middleware/rate_limiter.go
+++ b/middleware/rate_limiter.go
@@ -26,8 +26,8 @@ func NewRateLimiter(requestsPerInterval int, interval time.Duration) *RateLimite
 	}
 
 	middleware := func(next stk.HandlerFunc) stk.HandlerFunc {
-		return func(c *stk.Context) {
-			clientIP := c.Request.RemoteAddr
+		return func(c stk.Context) {
+			clientIP := c.GetRequest().RemoteAddr
 			rl.mux.Lock()
 			defer rl.mux.Unlock()
 

--- a/middleware/rate_limiter_test.go
+++ b/middleware/rate_limiter_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func dummyHandler(c *stk.Context) {
+func dummyHandler(c stk.Context) {
 	c.Status(http.StatusOK).JSONResponse("OK")
 }
 

--- a/middleware/security.go
+++ b/middleware/security.go
@@ -5,7 +5,7 @@ import (
 )
 
 func SecurityHeaders(next stk.HandlerFunc) stk.HandlerFunc {
-	return func(c *stk.Context) {
+	return func(c stk.Context) {
 		headers := map[string]string{
 			"X-Content-Type-Options":            "nosniff",
 			"X-Frame-Options":                   "SAMEORIGIN",
@@ -17,7 +17,7 @@ func SecurityHeaders(next stk.HandlerFunc) stk.HandlerFunc {
 		}
 
 		for key, value := range headers {
-			c.Writer.Header().Set(key, value)
+			c.SetHeader(key, value)
 		}
 
 		next(c)

--- a/middleware/security_test.go
+++ b/middleware/security_test.go
@@ -21,7 +21,7 @@ func TestSecurityHeaders(t *testing.T) {
 	s.Use(middleware.SecurityHeaders)
 
 	// Register a test route and handler
-	s.Get("/", func(c *stk.Context) {
+	s.Get("/", func(c stk.Context) {
 		c.Status(http.StatusOK).JSONResponse("OK")
 	})
 

--- a/server.go
+++ b/server.go
@@ -9,7 +9,7 @@ import (
 	"go.uber.org/zap"
 )
 
-type HandlerFunc func(*Context)
+type HandlerFunc func(Context)
 
 type ServerConfig struct {
 	Port           string
@@ -93,11 +93,11 @@ func wrapHandlerFunc(handler HandlerFunc, config *ServerConfig) httprouter.Handl
 			)
 		}
 
-		handlerContext := &Context{
-			Params:         p,
-			Request:        r,
-			Writer:         w,
-			Logger:         config.Logger,
+		handlerContext := &context{
+			params:         p,
+			request:        r,
+			writer:         w,
+			logger:         config.Logger,
 			allowedOrigins: config.AllowedOrigins,
 		}
 		handler(handlerContext)


### PR DESCRIPTION
- context struct now has limited exposure and the handlers can now avail the interface
- context methods can be used to interact with the server functions. This will provide more control over usage.
- reader and writer are still exposed via methods if we really want to make changes there.